### PR TITLE
Avoid loading the entire artifact into memory

### DIFF
--- a/gha-webhook-listener.py
+++ b/gha-webhook-listener.py
@@ -229,7 +229,7 @@ def deploy_tarball(artifact_url: str, target_dir: str) -> None:
     # into memory
     # TemporaryFile takes care of closing and deleting the file.
     with tempfile.TemporaryFile() as artifact_tmp:
-        for chunk in resp.iter_content():
+        for chunk in resp.iter_content(chunk_size=10*1024):
             artifact_tmp.write(chunk)
 
         artifact_tmp.seek(0)


### PR DESCRIPTION
Turns out that `requests.content` loads the entire response into memory at once, which isn't ideal. Let's spool it out to a temporary file.